### PR TITLE
fix img urls to jx-arch and model schemas in about/concepts

### DIFF
--- a/about/concepts/index.html
+++ b/about/concepts/index.html
@@ -350,11 +350,11 @@ are based on the comprehensive research done for the book <a href="https://goo.g
 
 <p>Jenkins X builds upon the DevOps model of loosely-coupled architectures and is designed to support you in deploying large numbers of distributed microservices in a repeatable and manageable fashion, across multiple teams.</p>
 
-<p><img src="https://jenkins-x.io/static/images/jx-arch.png" class="img-thumbnail"></p>
+<p><img src="https://jenkins-x.io/images/jx-arch.png" class="img-thumbnail"></p>
 
 <h3 id="conceptual-model">Conceptual model</h3>
 
-<p><img src="https://jenkins-x.io/static/images/model.png" class="img-thumbnail"></p>
+<p><img src="https://jenkins-x.io/images/model.png" class="img-thumbnail"></p>
 
 <h2 id="building-blocks">Building Blocks</h2>
 


### PR DESCRIPTION
Found that images are not displayed because of wrong url.
