### PR TITLE
hosting seems to have moved to GCR

### DIFF
--- a/categories/getting-started/index.xml
+++ b/categories/getting-started/index.xml
@@ -119,7 +119,7 @@ Well the Developing section contains the next steps you may want to try out, suc
       <pubDate>Mon, 01 Jul 2013 00:00:00 +0000</pubDate>
       
       <guid>https://jenkins-x.io/getting-started/create-custom-builder/</guid>
-      <description>In Jenkins X, it is possible to create your custom Builders (aka POD templates) or overwrite existing onces. You just need to base your Docker image on this builder-base image or on its slim version. These images contain a number of pre-installed tools which get constantly updated and published to Docker Hub.
+      <description>In Jenkins X, it is possible to create your custom Builders (aka POD templates) or overwrite existing onces. You just need to base your Docker image on this builder-base image or on its slim version. These images contain a number of pre-installed tools which get constantly updated and published to Google Container Registry.
 Create a custom Builder from scratch Builder image First you need to create a docker image for your builder.</description>
     </item>
     

--- a/getting-started/create-custom-builder/index.html
+++ b/getting-started/create-custom-builder/index.html
@@ -297,7 +297,7 @@ var trackOutboundLink = function(id, url) {
 
 <p>In Jenkins X, it is possible to create your custom Builders (aka <a href="https://github.com/jenkinsci/kubernetes-plugin">POD templates</a>) or overwrite existing onces. You just need to base your Docker
 image on this <a href="https://github.com/jenkins-x/builder-base/blob/master/Dockerfile.common">builder-base</a> image or on its <a href="https://github.com/jenkins-x/builder-base/blob/master/Dockerfile.slim">slim</a> version.
-These images contain a number of pre-installed tools which get constantly updated and published to <a href="https://hub.docker.com/r/jenkinsxio/builder-base/">Docker Hub</a>.</p>
+These images contain a number of pre-installed tools which get constantly updated and published to <a href="https://console.cloud.google.com/gcr/images/jenkinsxio/GLOBAL/builder-base?gcrImageListsize=30">Google Container Registry</a>.</p>
 
 <h2 id="create-a-custom-builder-from-scratch">Create a custom Builder from scratch</h2>
 


### PR DESCRIPTION
seems to have moved around the time of https://github.com/jenkins-x/jenkins-x-builders-base/commit/af9c9ff7e9b961e093f9f8ee5c01cbdf16cf0195

https://console.cloud.google.com/gcr/images/jenkinsxio/GLOBAL/builder-base?gcrImageListsize=30 shows more recent updates than https://hub.docker.com/r/jenkinsxio/builder-base/